### PR TITLE
fix(ci): skip SSH deploy when STAGING_HOST secret is absent

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -55,8 +55,19 @@ jobs:
           cache-from: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache
           cache-to: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache,mode=max
 
-      - name: Deploy to staging server
+      - name: Check staging host availability
+        id: staging-check
         if: steps.docker-login.outcome == 'success'
+        run: |
+          if [ -z "${{ secrets.STAGING_HOST }}" ]; then
+            echo "available=false" >> $GITHUB_OUTPUT
+            echo "::warning::STAGING_HOST not configured. SSH deploy skipped."
+          else
+            echo "available=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Deploy to staging server
+        if: steps.docker-login.outcome == 'success' && steps.staging-check.outputs.available == 'true'
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.STAGING_HOST }}
@@ -77,13 +88,13 @@ jobs:
               ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG_STAGING }}
 
       - name: Wait for service to be ready
-        if: steps.docker-login.outcome == 'success'
+        if: steps.docker-login.outcome == 'success' && steps.staging-check.outputs.available == 'true'
         run: |
           echo "Waiting for staging service to be ready..."
           sleep 10
 
       - name: Run smoke tests
-        if: steps.docker-login.outcome == 'success'
+        if: steps.docker-login.outcome == 'success' && steps.staging-check.outputs.available == 'true'
         run: |
           STAGING_URL="${{ secrets.STAGING_URL }}"
 
@@ -111,7 +122,7 @@ jobs:
           echo "Version: $version"
 
       - name: Notify deployment
-        if: steps.docker-login.outcome == 'success' && always()
+        if: steps.docker-login.outcome == 'success' && steps.staging-check.outputs.available == 'true' && always()
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}


### PR DESCRIPTION
## Problem

Deploy Staging workflow was failing on main with:
```
2026/05/18 05:56:16 Error: missing server host
```

The `Deploy to staging server` step used `appleboy/ssh-action` and ran whenever
Docker login succeeded (DOCKERHUB credentials ARE configured). But STAGING_HOST
is not configured as a secret, so the SSH action received an empty host string
and failed hard.

## Fix

Added a `Check staging host availability` step (id: `staging-check`) that checks
whether `STAGING_HOST` is non-empty and outputs `available=true/false`. The
Deploy, Wait, Smoke tests, and Notify steps are now gated on both
`steps.docker-login.outcome == 'success'` AND `steps.staging-check.outputs.available == 'true'`.

When STAGING_HOST is absent, the workflow emits a warning and exits cleanly (success).