### PR TITLE
ci(test): upgrade pnpm/action-setup to v4, fix e2e-test job ordering

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10.28.0
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -42,9 +40,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10.28.0
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -66,9 +62,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10.28.0
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -94,13 +88,12 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [build]
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10.28.0
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -110,6 +103,12 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: .next/
 
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps
@@ -142,9 +141,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10.28.0
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem

The `Test` workflow was broken in two ways:

1. All 5 jobs used the deprecated `pnpm/action-setup@v2` action with an explicit `version:` pin. The v2 action runs on Node.js 20 which GitHub is forcing to Node.js 24 on 2026-06-02, and v2 cannot forward `pnpm` version discovery correctly when the runner switches runtimes.

2. The `e2e-test` job had no `needs:` dependency on `build`, causing it to run in parallel with (or before) the build job — meaning the `.next/` artifact it needs may not exist yet.

## Fix

- Replace `pnpm/action-setup@v2` with `@v4` in all 5 jobs. v4 reads the pnpm version from the `packageManager` field in `package.json` (`pnpm@10.28.0`), removing the need for an explicit `version:` pin.
- Add `needs: [build]` to `e2e-test` so it waits for the production build.
- Add a `Download build artifact` step to `e2e-test` to restore `.next/` from the build job's uploaded artifact.

## Test plan

- [ ] Lint: `pnpm install` succeeds, ESLint and Prettier pass
- [ ] TypeScript Type Check: `pnpm install` succeeds, `tsc` passes
- [ ] Unit Tests: `pnpm install` succeeds, Jest passes
- [ ] Production Build: `pnpm install` succeeds, `next build` succeeds
- [ ] E2E Tests: waits for build job, downloads `.next/`, Playwright runs