### PR TITLE
fix(ci): Production Build false-green — include hidden .next/ artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,7 @@ jobs:
         with:
           name: build
           path: .next/
+          merge-multiple: false
 
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps
@@ -154,6 +155,19 @@ jobs:
 
       - name: Build application
         run: pnpm run build
+        env:
+          NODE_ENV: production
+          NEXT_TELEMETRY_DISABLED: 1
+
+      - name: Verify build output
+        run: |
+          if [ -d ".next" ]; then
+            echo "Build successful"
+            du -sh .next
+          else
+            echo "Build failed - no .next directory"
+            exit 1
+          fi
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -161,3 +175,5 @@ jobs:
           name: build
           path: .next/
           retention-days: 7
+          include-hidden-files: true
+          if-no-files-found: error


### PR DESCRIPTION
## Root Cause

`actions/upload-artifact@v4` defaults to `include-hidden-files: false`. The `.next/` directory is a hidden dotdir (starts with `.`), so it was silently skipped by the upload step. The build completed successfully and produced `.next/`, but the upload logged only a `##[warning]No files were found` and exited 0 — making `Production Build` a false-green. The `e2e-test` job then failed at `Download build artifact` with `Artifact not found for name: build` before any test could run.

Confirmed via run 26087141121: `next build --webpack` ran for ~6 minutes, printed the full route table, and completed successfully. The upload step immediately after showed `include-hidden-files: false` in its inputs and then the no-files warning.

## Fix

- `include-hidden-files: true` on the upload step so `.next/` is included
- `if-no-files-found: error` so `Production Build` genuinely fails if `.next/` is missing
- `NODE_ENV: production` + `NEXT_TELEMETRY_DISABLED: 1` on the build step (matches `ci.yml`)
- Added `Verify build output` step to fail fast before reaching the upload
- `merge-multiple: false` on the download step for explicitness

No code changes. No version bump. Workflow file only.