### PR TITLE
fix(ci): fix docker-publish/sbom/lighthouse reds on main (P103)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,6 +42,22 @@ jobs:
           echo "minor=$(echo $VERSION | cut -d. -f1-2)" >> "$GITHUB_OUTPUT"
           echo "Building nself-admin v$VERSION"
 
+      - name: Resolve CLI version for Dockerfile
+        id: cli_version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Use the same version as admin when the CLI release exists; otherwise use latest stable.
+          ADMIN_VER="${{ steps.version.outputs.version }}"
+          if gh release view "v${ADMIN_VER}" --repo nself-org/cli &>/dev/null; then
+            CLI_VER="$ADMIN_VER"
+            echo "Using CLI version matching admin: $CLI_VER"
+          else
+            CLI_VER="$(gh release view --repo nself-org/cli --json tagName --jq '.tagName' | sed 's/^v//')"
+            echo "CLI v${ADMIN_VER} not published yet — using latest stable CLI: $CLI_VER"
+          fi
+          echo "cli_version=$CLI_VER" >> "$GITHUB_OUTPUT"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -74,6 +90,7 @@ jobs:
           tags: ${{ env.DOCKER_IMAGE }}:scan-${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
+          build-args: NSELF_VERSION=${{ steps.cli_version.outputs.cli_version }}
           cache-from: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache
           cache-to: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache,mode=max
 
@@ -110,6 +127,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+          build-args: NSELF_VERSION=${{ steps.cli_version.outputs.cli_version }}
           cache-from: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache
           cache-to: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache,mode=max
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -41,8 +41,19 @@ jobs:
         run: |
           pnpm start &
           echo "Waiting for app to start..."
-          sleep 20
-          curl --retry 10 --retry-delay 3 http://localhost:3021/api/health
+          # Poll until the health endpoint responds or timeout after 90s.
+          # A fixed sleep(20) is insufficient on slow CI runners; the app can take 40-60s
+          # to hydrate, causing Lighthouse NO_FCP failures on the first run attempt.
+          DEADLINE=$((SECONDS + 90))
+          until curl -sf http://localhost:3021/api/health >/dev/null 2>&1; do
+            if [ $SECONDS -ge $DEADLINE ]; then
+              echo "ERROR: app did not become healthy within 90s"
+              exit 1
+            fi
+            echo "  waiting... ($SECONDS s elapsed)"
+            sleep 3
+          done
+          echo "App is healthy after ${SECONDS}s"
 
       - name: Run Lighthouse audit
         id: lighthouse

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -6,9 +6,11 @@ name: SBOM — Generate and Sign
 # Depends on: release.yml (same trigger: push to v*)
 
 on:
-  push:
-    tags:
-      - 'v*'
+  # Trigger on published releases so the GH Release asset target always exists.
+  # The prior tag-push trigger fired before `gh release create` ran, causing
+  # "release not found" errors on every release cycle.
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
@@ -34,6 +36,8 @@ jobs:
         run: |
           if [ -n "${{ github.event.inputs.version }}" ]; then
             echo "tag=v${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ github.event.release.tag_name }}" ]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
           else
             echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary

Three real CI failures on `main` — all Path-A root-cause fixes, no skips or `continue-on-error`.

### docker-publish — 404 on nself CLI download

**Root cause:** `Dockerfile` fetches the CLI binary from `nself-org/cli/releases/download/v${NSELF_VERSION}`. The admin v1.1.3 tag fired the workflow before `nself-org/cli v1.1.3` was published (published next day), causing a 404 that failed the build.

**Fix:** Add a "Resolve CLI version for Dockerfile" step that checks whether `nself-org/cli vX.Y.Z` exists; falls back to latest stable CLI release if not. Pass resolved version via `build-args` to both the scan build and the multi-arch push build.

### sbom — "release not found" on gh release upload

**Root cause:** Workflow triggered on `push.tags: v*`, which fires the instant the git tag is pushed. The GitHub Release is created seconds-to-minutes later (manual or via release.yml). `gh release upload "vX.Y.Z"` ran before the Release existed.

**Fix:** Change trigger from `push.tags` to `release.types: [published]`. Release is guaranteed to exist by the time the workflow runs. Version resolution updated to use `github.event.release.tag_name` when triggered by the release event.

### lighthouse — NO_FCP on slow CI runners

**Root cause:** Fixed `sleep 20` insufficient on slow runners; app takes 40–60s to hydrate. Lighthouse started before the app painted any content, producing a NO_FCP runtime error (exit code 1).

**Fix:** Replace `sleep 20` + single `curl --retry` with a 90s polling loop (3s intervals) that waits for `http://localhost:3021/api/health` to respond before starting Lighthouse. Includes a hard timeout to fail fast if the app never starts.

## Test plan

- [ ] `docker-publish` — triggered on release tag; CLI version falls back correctly; Trivy scan passes; multi-arch manifest verified
- [ ] `sbom` — triggered on release published event; `gh release upload` succeeds because Release exists; cosign bundle attached
- [ ] `lighthouse` — polling loop waits for healthy app before audit; NO_FCP eliminated; performance score ≥50 or justification provided