### PR TITLE
chore(release): admin v1.1.4 (CLI lockstep)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nself-admin",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": false,
   "description": "Web-based administration interface for nself CLI backend stack",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/lib/cli-version.ts
+++ b/src/lib/cli-version.ts
@@ -11,4 +11,4 @@
  *
  * To update: bump all three files atomically as part of the release process.
  */
-export const CLI_VERSION = '1.1.3'
+export const CLI_VERSION = '1.1.4'


### PR DESCRIPTION
PATCH release bumping admin from 1.1.3 to 1.1.4 to maintain CLI=Admin lockstep (cli is already at v1.1.4; cli binary Release is blocked until admin reaches 1.1.4).

## Changes
- `package.json`: version 1.1.3 -> 1.1.4
- `src/lib/cli-version.ts`: CLI_VERSION 1.1.3 -> 1.1.4

Version lockstep verified locally across all three sources (package.json, cli-version.ts, cli/version.go) at v1.1.4.