### PR TITLE
chore(git): harden .gitignore for binary exclusions (Mega P1 T-E3-03)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ PLAN.md
 .gemini/
 .codeium/
 .claude/
+
+# Turbo cache (Mega P1 T-E3-03 hardening)
+.turbo/


### PR DESCRIPTION
## Summary
- Adds `.turbo/` to .gitignore — Turbo build cache directory was missing

## Context
Part of Mega Phase 1 T-E3-03: harden .gitignore files across all nself repos to prevent build artifacts from being tracked.