### PR TITLE
chore: bump Dockerfile to v1.1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN ARCH=$(uname -m) && \
     chmod +x /usr/local/bin/mkcert
 
 # Install nself CLI pre-built binary
-ARG NSELF_VERSION=1.1.3
+ARG NSELF_VERSION=1.1.4
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then NSELF_ARCH="amd64"; \
     elif [ "$ARCH" = "aarch64" ]; then NSELF_ARCH="arm64"; \
@@ -122,7 +122,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ENV HOSTNAME="0.0.0.0"
 # Port 3021 is the reserved port for nself-admin (not 3100, which is for Loki)
 ENV PORT=3021
-ENV ADMIN_VERSION=1.1.3
+ENV ADMIN_VERSION=1.1.4
 
 # Environment variables that can be set at runtime:
 # NSELF_PROJECT_PATH - Path to mounted project (default: /workspace)
@@ -132,7 +132,7 @@ ENV ADMIN_VERSION=1.1.3
 # Add labels for container metadata
 LABEL org.opencontainers.image.title="nself-admin"
 LABEL org.opencontainers.image.description="Web-based administration interface for nself CLI"
-LABEL org.opencontainers.image.version="1.1.3"
+LABEL org.opencontainers.image.version="1.1.4"
 LABEL org.opencontainers.image.vendor="nself.org"
 LABEL org.opencontainers.image.source="https://github.com/nself-org/admin"
 LABEL org.opencontainers.image.licenses="Proprietary - Free for personal use, Commercial license required"


### PR DESCRIPTION
## Summary
- Bumps `ARG NSELF_VERSION`, `ENV ADMIN_VERSION`, and OCI image version label from `1.1.3` → `1.1.4`
- Required to satisfy the Version Lockstep CI check in nself/cli that scans all version files including admin's Dockerfile

## Changes
- `Dockerfile` line 91: `ARG NSELF_VERSION=1.1.4`
- `Dockerfile` line 125: `ENV ADMIN_VERSION=1.1.4`
- `Dockerfile` line 135: `LABEL org.opencontainers.image.version="1.1.4"`