### PR TITLE
chore(release): admin v1.1.5 (CLI lockstep)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN ARCH=$(uname -m) && \
     chmod +x /usr/local/bin/mkcert
 
 # Install nself CLI pre-built binary
-ARG NSELF_VERSION=1.1.4
+ARG NSELF_VERSION=1.1.5
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then NSELF_ARCH="amd64"; \
     elif [ "$ARCH" = "aarch64" ]; then NSELF_ARCH="arm64"; \
@@ -122,7 +122,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ENV HOSTNAME="0.0.0.0"
 # Port 3021 is the reserved port for nself-admin (not 3100, which is for Loki)
 ENV PORT=3021
-ENV ADMIN_VERSION=1.1.4
+ENV ADMIN_VERSION=1.1.5
 
 # Environment variables that can be set at runtime:
 # NSELF_PROJECT_PATH - Path to mounted project (default: /workspace)
@@ -132,7 +132,7 @@ ENV ADMIN_VERSION=1.1.4
 # Add labels for container metadata
 LABEL org.opencontainers.image.title="nself-admin"
 LABEL org.opencontainers.image.description="Web-based administration interface for nself CLI"
-LABEL org.opencontainers.image.version="1.1.4"
+LABEL org.opencontainers.image.version="1.1.5"
 LABEL org.opencontainers.image.vendor="nself.org"
 LABEL org.opencontainers.image.source="https://github.com/nself-org/admin"
 LABEL org.opencontainers.image.licenses="Proprietary - Free for personal use, Commercial license required"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nself-admin",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "private": false,
   "description": "Web-based administration interface for nself CLI backend stack",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/lib/cli-version.ts
+++ b/src/lib/cli-version.ts
@@ -11,4 +11,4 @@
  *
  * To update: bump all three files atomically as part of the release process.
  */
-export const CLI_VERSION = '1.1.4'
+export const CLI_VERSION = '1.1.5'


### PR DESCRIPTION
## Summary
- Bumps all admin version references to match CLI v1.1.5 lockstep
- `package.json`: 1.1.4 → 1.1.5
- `src/lib/cli-version.ts`: CLI_VERSION 1.1.4 → 1.1.5
- `Dockerfile`: all three version labels (ARG NSELF_VERSION, ENV ADMIN_VERSION, LABEL image.version)

## Part of Mega Phase 1
Completing the version lockstep chain. CLI PR #123 bumps the CLI-side files; this PR handles the admin-side files.

## Test plan
- [ ] Admin lockstep CI passes (checks package.json == cli-version.ts)
- [ ] Docker build image label correct