### PR TITLE
chore: add lefthook local CI hooks and ci:local script

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,29 @@
+# lefthook.yml — nself/admin (Next.js, pnpm)
+# Install: brew install lefthook && lefthook install (at repo root)
+
+pre-commit:
+  parallel: true
+  commands:
+    lint:
+      glob: "src/**/*.{ts,tsx,js,jsx}"
+      run: pnpm lint
+    format-check:
+      glob: "**/*.{ts,tsx,js,jsx,json,md}"
+      run: pnpm exec prettier --check {staged_files}
+    secrets-scan:
+      run: |
+        if [ -f .github/gitleaks.toml ]; then
+          gitleaks protect --staged --config .github/gitleaks.toml
+        else
+          gitleaks protect --staged
+        fi
+
+pre-push:
+  parallel: false
+  commands:
+    type-check:
+      run: pnpm type-check
+    test:
+      run: pnpm test:ci
+    build:
+      run: pnpm build

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "version:bump:patch": "npm version patch --no-git-tag-version",
     "version:bump:minor": "npm version minor --no-git-tag-version",
     "version:bump:major": "npm version major --no-git-tag-version",
-    "release": "pnpm build && pnpm docker:push"
+    "release": "pnpm build && pnpm docker:push",
+    "ci:local": "pnpm lint && pnpm type-check && pnpm format:check && pnpm test:ci && pnpm build"
   },
   "packageManager": "pnpm@10.28.0",
   "browserslist": "defaults, not ie <= 11",


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` with pre-commit (format/lint/gitleaks) and pre-push (typecheck/test/build) hooks
- Adds `ci:local` (pnpm) or `ci-local` (make) entry point that mirrors the remote CI gate order
- Framework supports `act` for running Linux GitHub Actions jobs locally without GH minutes

## Stack-specific gates

See `.claude/docs/CI-LOCAL.md` in the project root for the full per-repo table, `act` usage, and the `nself ci` dogfood roadmap (P2 E4).

## Test plan

- [ ] `brew install lefthook && lefthook install` in this repo
- [ ] Verify pre-commit hook fires on `git commit`
- [ ] Run `pnpm ci:local` / `make ci-local` and confirm gates pass
- [ ] `act --list` shows expected jobs (requires Docker)