### PR TITLE
chore(release): v1.1.8 version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nself-admin",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "private": false,
   "description": "Web-based administration interface for nself CLI backend stack",
   "license": "MIT",

--- a/src/lib/cli-version.ts
+++ b/src/lib/cli-version.ts
@@ -11,4 +11,4 @@
  *
  * To update: bump all three files atomically as part of the release process.
  */
-export const CLI_VERSION = '1.1.7'
+export const CLI_VERSION = '1.1.8'


### PR DESCRIPTION
Version bump to v1.1.8 — lockstep with cli.

P2 phase complete. PR #41 merged.

Updates: `package.json`, `src/lib/cli-version.ts`.