### PR TITLE
chore(release): bump version to v1.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nself-admin",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "private": false,
   "description": "Web-based administration interface for nself CLI backend stack",
   "license": "MIT",

--- a/src/lib/cli-version.ts
+++ b/src/lib/cli-version.ts
@@ -11,4 +11,4 @@
  *
  * To update: bump all three files atomically as part of the release process.
  */
-export const CLI_VERSION = '1.1.8'
+export const CLI_VERSION = '1.1.9'


### PR DESCRIPTION
## P2 EOP — version bump v1.1.8 → v1.1.9 (lockstep with cli)

Bumps admin version to v1.1.9 to maintain lockstep with `cli/` v1.1.9.

### Version files updated
- `admin/package.json`
- `admin/src/lib/cli-version.ts`

### Lockstep
CLI and admin maintain version lockstep (enforced since P93). This bump tracks the P2 EOP security hardening (D1-03..D1-06) that shipped in v1.1.8.