### PR TITLE
chore(release): bump version to v1.2.0 — CLI/Admin lockstep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN ARCH=$(uname -m) && \
     chmod +x /usr/local/bin/mkcert
 
 # Install nself CLI pre-built binary
-ARG NSELF_VERSION=1.1.7
+ARG NSELF_VERSION=1.2.0
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then NSELF_ARCH="amd64"; \
     elif [ "$ARCH" = "aarch64" ]; then NSELF_ARCH="arm64"; \
@@ -122,7 +122,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ENV HOSTNAME="0.0.0.0"
 # Port 3021 is the reserved port for nself-admin (not 3100, which is for Loki)
 ENV PORT=3021
-ENV ADMIN_VERSION=1.1.7
+ENV ADMIN_VERSION=1.2.0
 
 # Environment variables that can be set at runtime:
 # NSELF_PROJECT_PATH - Path to mounted project (default: /workspace)
@@ -132,7 +132,7 @@ ENV ADMIN_VERSION=1.1.7
 # Add labels for container metadata
 LABEL org.opencontainers.image.title="nself-admin"
 LABEL org.opencontainers.image.description="Web-based administration interface for nself CLI"
-LABEL org.opencontainers.image.version="1.1.7"
+LABEL org.opencontainers.image.version="1.2.0"
 LABEL org.opencontainers.image.vendor="nself.org"
 LABEL org.opencontainers.image.source="https://github.com/nself-org/admin"
 LABEL org.opencontainers.image.licenses="Proprietary - Free for personal use, Commercial license required"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nself-admin",
-  "version": "1.1.11",
+  "version": "1.2.0",
   "private": false,
   "description": "Web-based administration interface for nself CLI backend stack",
   "license": "MIT",

--- a/src/lib/cli-version.ts
+++ b/src/lib/cli-version.ts
@@ -11,4 +11,4 @@
  *
  * To update: bump all three files atomically as part of the release process.
  */
-export const CLI_VERSION = '1.1.11'
+export const CLI_VERSION = '1.2.0'


### PR DESCRIPTION
## Summary
- Aligns all admin version-carrying files to v1.2.0 to match cli PR #152 (fix/ci-green-main-2026-06-30)
- Required for the version lockstep gate to pass on the v1.2.0 tag push

## Files changed
| File | From | To |
|------|------|----|
| `package.json` | 1.1.11 | 1.2.0 |
| `src/lib/cli-version.ts` | 1.1.11 | 1.2.0 |
| `Dockerfile` ARG NSELF_VERSION | 1.1.7 | 1.2.0 |
| `Dockerfile` ENV ADMIN_VERSION | 1.1.7 | 1.2.0 |
| `Dockerfile` LABEL image.version | 1.1.7 | 1.2.0 |

## Lockstep check
Run locally: `NSELF_ADMIN_ROOT=/path/to/admin bash cli/scripts/check-version-lockstep.sh`