### PR TITLE
fix(e2e): retarget dead-route specs to live pages — fixes chronic E2E failures

### DIFF
--- a/src/app/system/diagnostics/page.tsx
+++ b/src/app/system/diagnostics/page.tsx
@@ -11,14 +11,7 @@
 
 import { Button } from '@/components/Button'
 import { ListSkeleton } from '@/components/skeletons'
-import {
-  AlertTriangle,
-  CheckCircle,
-  RefreshCw,
-  Stethoscope,
-  WifiOff,
-  XCircle,
-} from 'lucide-react'
+import { AlertTriangle, CheckCircle, RefreshCw, Stethoscope, WifiOff, XCircle } from 'lucide-react'
 import { Suspense, useCallback, useEffect, useState } from 'react'
 
 interface DiagnosticCheck {
@@ -169,9 +162,7 @@ function DiagnosticsContent() {
       {/* Overall status banner */}
       <div
         className={`flex items-center gap-3 rounded-lg border p-4 ${
-          isHealthy
-            ? 'border-green-500/30 bg-green-500/10'
-            : 'border-red-500/30 bg-red-500/10'
+          isHealthy ? 'border-green-500/30 bg-green-500/10' : 'border-red-500/30 bg-red-500/10'
         }`}
       >
         {isHealthy ? (
@@ -215,9 +206,7 @@ function DiagnosticsContent() {
               <div className="min-w-0 flex-1">
                 <p className="font-medium text-white">{check.name}</p>
                 <p className="mt-0.5 text-sm text-gray-400">{check.message}</p>
-                {check.detail && (
-                  <p className="mt-1 text-xs text-gray-500">{check.detail}</p>
-                )}
+                {check.detail && <p className="mt-1 text-xs text-gray-500">{check.detail}</p>}
               </div>
               <span
                 className={`shrink-0 rounded px-2 py-0.5 text-xs font-medium ${

--- a/src/app/system/trust/page.tsx
+++ b/src/app/system/trust/page.tsx
@@ -11,7 +11,16 @@
 
 import { Button } from '@/components/Button'
 import { ListSkeleton } from '@/components/skeletons'
-import { AlertTriangle, CheckCircle, Globe, Lock, Network, RefreshCw, WifiOff, XCircle } from 'lucide-react'
+import {
+  AlertTriangle,
+  CheckCircle,
+  Globe,
+  Lock,
+  Network,
+  RefreshCw,
+  WifiOff,
+  XCircle,
+} from 'lucide-react'
 import { Suspense, useCallback, useEffect, useState } from 'react'
 
 interface TrustData {
@@ -131,7 +140,8 @@ function TrustContent() {
   }
 
   // Normalise between real API shape and test-mock shape
-  const sslTrusted = data.ssl?.trusted ?? data.ssl?.caInstalled ?? data.certificateInstalled ?? false
+  const sslTrusted =
+    data.ssl?.trusted ?? data.ssl?.caInstalled ?? data.certificateInstalled ?? false
   const dnsConfigured = data.dns?.configured ?? data.dnsConfigured ?? false
   const portsForwarded = data.ports?.forwarded ?? data.portForwardingActive ?? false
 

--- a/src/app/system/validate/page.tsx
+++ b/src/app/system/validate/page.tsx
@@ -175,9 +175,7 @@ function ValidateContent() {
       {/* Overall status */}
       <div
         className={`flex items-center gap-3 rounded-lg border p-4 ${
-          isValid
-            ? 'border-green-500/30 bg-green-500/10'
-            : 'border-red-500/30 bg-red-500/10'
+          isValid ? 'border-green-500/30 bg-green-500/10' : 'border-red-500/30 bg-red-500/10'
         }`}
       >
         {isValid ? (
@@ -187,7 +185,9 @@ function ValidateContent() {
         )}
         <div>
           <p className={`font-medium ${isValid ? 'text-green-400' : 'text-red-400'}`}>
-            {isValid ? 'Configuration is valid' : `${failed} validation error${failed !== 1 ? 's' : ''} found`}
+            {isValid
+              ? 'Configuration is valid'
+              : `${failed} validation error${failed !== 1 ? 's' : ''} found`}
           </p>
           <p className="mt-0.5 text-sm text-gray-400">
             {passed} passed · {failed} failed · {warnings} warnings
@@ -202,18 +202,14 @@ function ValidateContent() {
           <ClipboardCheck className="mx-auto mb-3 h-8 w-8 text-gray-500" />
           <p className="text-gray-400">No validation checks found.</p>
           <p className="mt-1 text-sm text-gray-500">
-            Run{' '}
-            <code className="font-mono text-sky-400">nself config validate</code> to generate
+            Run <code className="font-mono text-sky-400">nself config validate</code> to generate
             results.
           </p>
         </div>
       ) : (
         <div className="space-y-2">
           {checks.map((check, i) => (
-            <div
-              key={i}
-              className="rounded-lg border border-white/10 bg-white/[0.02] px-4 py-3"
-            >
+            <div key={i} className="rounded-lg border border-white/10 bg-white/[0.02] px-4 py-3">
               <div className="flex items-start gap-3">
                 {check.status === 'pass' ? (
                   <CheckCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-green-400" />
@@ -233,9 +229,7 @@ function ValidateContent() {
                   </div>
                   <p className="mt-0.5 text-sm text-gray-400">{check.message}</p>
                   {check.suggestion && (
-                    <p className="mt-1 text-xs text-sky-400">
-                      Fix: {check.suggestion}
-                    </p>
+                    <p className="mt-1 text-xs text-sky-400">Fix: {check.suggestion}</p>
                   )}
                 </div>
                 <span

--- a/src/app/system/version/page.tsx
+++ b/src/app/system/version/page.tsx
@@ -159,21 +159,17 @@ function VersionContent() {
       {/* Version cards */}
       <div className="grid gap-4 sm:grid-cols-2">
         <div className="rounded-lg border border-white/10 bg-white/5 p-5">
-          <div className="flex items-center gap-2 text-gray-400 text-sm mb-3">
+          <div className="mb-3 flex items-center gap-2 text-sm text-gray-400">
             <Tag className="h-4 w-4" />
             <span>CLI Version</span>
           </div>
           <p className="font-mono text-2xl font-bold text-white">{cliVersion}</p>
-          {buildDate && (
-            <p className="mt-1 text-xs text-gray-500">Built {buildDate}</p>
-          )}
-          {commit && (
-            <p className="mt-0.5 font-mono text-xs text-gray-600">{commit}</p>
-          )}
+          {buildDate && <p className="mt-1 text-xs text-gray-500">Built {buildDate}</p>}
+          {commit && <p className="mt-0.5 font-mono text-xs text-gray-600">{commit}</p>}
         </div>
 
         <div className="rounded-lg border border-white/10 bg-white/5 p-5">
-          <div className="flex items-center gap-2 text-gray-400 text-sm mb-3">
+          <div className="mb-3 flex items-center gap-2 text-sm text-gray-400">
             <Tag className="h-4 w-4" />
             <span>Admin Panel</span>
           </div>

--- a/tests/e2e/14-dev-dashboard-pages.spec.ts
+++ b/tests/e2e/14-dev-dashboard-pages.spec.ts
@@ -2,9 +2,15 @@
  * E2E tests for S32 dev/* and dashboard/* pages:
  *
  * dev:       /dev/graphql · /dev/terminal · /dev/api · /dev/scaffold
- *            /dev/seed · /dev/types · /dev/webhooks · /dev/testing
+ *            /dev/types · /dev/webhooks · /dev/testing
  * dashboard: /dashboard/alerts · /dashboard/health · /dashboard/logs
- *            /dashboard/metrics · /dashboard/status
+ *            /dashboard/metrics
+ *
+ * Note: /dev/seed and /dashboard/status were quarantined as dead pages
+ * (commit 6bf776a). Their live successors — /database/seed
+ * (src/app/database/seed/page.tsx) and /uptime (src/app/uptime/page.tsx) —
+ * are covered under their own describe blocks below with the correct
+ * /api/database/seed and /api/uptime contracts.
  *
  * Each suite verifies all 7 UI states:
  *   1. Initial skeleton rendered while loading
@@ -237,45 +243,57 @@ test.describe('/dev/scaffold', () => {
 
 // ─────────────────────────────────────────────────────────────────────────────
 
-test.describe('/dev/seed', () => {
+// NOTE: the real page for seed management lives at /database/seed
+// (src/app/database/seed/page.tsx), not /dev/seed — /dev/seed was quarantined
+// as a dead page (commit 6bf776a). It GETs /api/database/seed, which returns
+// `{ success, data: Seed[] }` (see src/types/database.ts) — not the
+// `{ seeded, tables }` shape this suite previously mocked. There is also no
+// retry button on fetch failure: fetchSeeds() catches the error and falls
+// back to an empty seed list silently. This block mirrors the actual
+// component contract instead of the stale dead-route assumptions.
+test.describe('/database/seed', () => {
   test.beforeEach(async ({ page }) => {
     await setupAuth(page)
   })
 
-  test('navigates to /dev/seed', async ({ page }) => {
-    await page.goto('/dev/seed', { waitUntil: 'commit' })
-    await expect(page).toHaveURL(/\/dev\/seed/)
+  test('navigates to /database/seed', async ({ page }) => {
+    await mockApiEndpoint(page, '**/api/database/seed', { success: true, data: [] })
+    await page.goto('/database/seed', { waitUntil: 'commit' })
+    await expect(page).toHaveURL(/\/database\/seed/)
   })
 
-  test('success state: shows seed status and action buttons', async ({ page }) => {
+  test('success state: shows seed list and action buttons', async ({ page }) => {
     await mockApiEndpoint(page, '**/api/database/seed', {
-      seeded: true,
-      tables: [{ name: 'np_users', rowCount: 5 }],
-      lastSeededAt: new Date().toISOString(),
+      success: true,
+      data: [{ name: 'np_users.sql', type: 'local', status: 'available', recordCount: 5 }],
     })
-    await page.goto('/dev/seed', { waitUntil: 'commit' })
+    await page.goto('/database/seed', { waitUntil: 'commit' })
     await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByText(/seeded|run seed|np_users/i).first()).toBeVisible()
+    await expect(page.getByText(/np_users\.sql/i).first()).toBeVisible()
+    await expect(page.getByRole('button', { name: /run all seeds/i })).toBeVisible()
   })
 
-  test('run seed button visible', async ({ page }) => {
-    await mockApiEndpoint(page, '**/api/database/seed', {
-      seeded: false,
-      tables: [],
-    })
-    await page.goto('/dev/seed', { waitUntil: 'commit' })
+  test('empty state: shows zero-count stats and no seed files', async ({ page }) => {
+    await mockApiEndpoint(page, '**/api/database/seed', { success: true, data: [] })
+    await page.goto('/database/seed', { waitUntil: 'commit' })
     await page.waitForLoadState('domcontentloaded')
-    const btn = page.getByRole('button', { name: /run seed/i })
-    if (await btn.isVisible()) {
-      await expect(btn).toBeVisible()
-    }
+    // Rendered as "No common seeds seeds found" — renderSeedList interpolates
+    // `No ${title.toLowerCase()} seeds found` with title "Common Seeds", so
+    // match on the stable prefix only.
+    await expect(page.getByText(/no common seeds/i).first()).toBeVisible()
   })
 
-  test('offline state: shows retry on abort', async ({ page }) => {
+  test('offline: fetch abort falls back to empty seed list (no crash)', async ({ page }) => {
     await page.route('**/api/database/seed', (route) => route.abort('failed'))
-    await page.goto('/dev/seed', { waitUntil: 'commit' })
+    await page.goto('/database/seed', { waitUntil: 'commit' })
     await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByRole('button', { name: /retry/i })).toBeVisible()
+    // fetchSeeds() swallows the error and renders the empty state — there is
+    // no retry affordance on this page, so assert the page stays usable.
+    await expect(page.getByText(/database seeding/i).first()).toBeVisible()
+    // Rendered as "No common seeds seeds found" — renderSeedList interpolates
+    // `No ${title.toLowerCase()} seeds found` with title "Common Seeds", so
+    // match on the stable prefix only.
+    await expect(page.getByText(/no common seeds/i).first()).toBeVisible()
   })
 
   test('redirect to login when unauthenticated', async ({ page }) => {
@@ -285,7 +303,7 @@ test.describe('/dev/seed', () => {
     // assertion below validates the outcome regardless of how the
     // navigation surface terminated.
     try {
-      await page.goto('/dev/seed', { waitUntil: 'commit' })
+      await page.goto('/database/seed', { waitUntil: 'commit' })
       await page.waitForLoadState('domcontentloaded')
     } catch (e) {
       if (!/interrupted by another navigation/i.test(String(e))) throw e
@@ -781,95 +799,114 @@ test.describe('/dashboard/metrics', () => {
 
 // ─────────────────────────────────────────────────────────────────────────────
 
-test.describe('/dashboard/status', () => {
+// NOTE: /dashboard/status was quarantined as a dead page (commit 6bf776a).
+// The live successor is /uptime (src/app/uptime/page.tsx): it GETs /api/uptime
+// which returns `{ generatedAt, services: ServiceUptime[], overallUptimePct }`.
+// On fetch failure it renders an inline error banner (no dedicated retry
+// button — the always-present "Refresh" button re-triggers the load), so the
+// assertions below match that actual contract.
+test.describe('/uptime', () => {
   test.beforeEach(async ({ page }) => {
     await setupAuth(page)
   })
 
-  test('navigates to /dashboard/status', async ({ page }) => {
-    await page.goto('/dashboard/status', { waitUntil: 'commit' })
-    await expect(page).toHaveURL(/\/dashboard\/status/)
+  const upReport = {
+    generatedAt: new Date().toISOString(),
+    overallUptimePct: 100,
+    services: [
+      {
+        name: 'PostgreSQL',
+        url: 'http://localhost:5432',
+        status: 'up',
+        latencyMs: 2,
+        checkedAt: new Date().toISOString(),
+        uptimePct24h: 100,
+        lastIncidentAt: null,
+        httpStatus: 200,
+        errorMessage: null,
+      },
+      {
+        name: 'Hasura GraphQL',
+        url: 'http://localhost:8080',
+        status: 'up',
+        latencyMs: 8,
+        checkedAt: new Date().toISOString(),
+        uptimePct24h: 99.99,
+        lastIncidentAt: null,
+        httpStatus: 200,
+        errorMessage: null,
+      },
+    ],
+  }
+
+  test('navigates to /uptime', async ({ page }) => {
+    await mockApiEndpoint(page, '**/api/uptime**', upReport)
+    await page.goto('/uptime', { waitUntil: 'commit' })
+    await expect(page).toHaveURL(/\/uptime/)
   })
 
-  test('success state: shows overall banner and component list', async ({ page }) => {
-    await mockApiEndpoint(page, '**/api/monitor', {
-      overall: 'operational',
-      components: [
-        {
-          id: 'pg',
-          name: 'PostgreSQL',
-          category: 'core',
-          status: 'operational',
-          responseTimeMs: 2,
-        },
-        {
-          id: 'hasura',
-          name: 'Hasura GraphQL',
-          category: 'core',
-          status: 'operational',
-          responseTimeMs: 8,
-        },
-      ],
-      uptime: { day: 100, week: 99.99, month: 99.97 },
-      checkedAt: new Date().toISOString(),
-    })
-    await page.goto('/dashboard/status', { waitUntil: 'commit' })
+  test('success state: shows overall uptime and service list', async ({ page }) => {
+    await mockApiEndpoint(page, '**/api/uptime**', upReport)
+    await page.goto('/uptime', { waitUntil: 'commit' })
     await page.waitForLoadState('domcontentloaded')
-    await expect(
-      page.getByText(/all systems operational|PostgreSQL|operational/i).first()
-    ).toBeVisible()
+    await expect(page.getByText('24h overall uptime')).toBeVisible()
+    await expect(page.getByText('PostgreSQL')).toBeVisible()
   })
 
-  test('degraded overall: shows warning banner', async ({ page }) => {
-    await mockApiEndpoint(page, '**/api/monitor', {
-      overall: 'degraded',
-      components: [
+  test('degraded service: shows error message and uptime badge', async ({ page }) => {
+    await mockApiEndpoint(page, '**/api/uptime**', {
+      generatedAt: new Date().toISOString(),
+      overallUptimePct: 98.5,
+      services: [
         {
-          id: 'redis',
           name: 'Redis',
-          category: 'optional',
+          url: 'http://localhost:6379',
           status: 'degraded',
-          message: 'High latency',
+          latencyMs: 420,
+          checkedAt: new Date().toISOString(),
+          uptimePct24h: 98.5,
+          lastIncidentAt: new Date().toISOString(),
+          httpStatus: 200,
+          errorMessage: 'High latency',
         },
       ],
-      uptime: { day: 98.5, week: 99.1, month: 99.5 },
-      checkedAt: new Date().toISOString(),
     })
-    await page.goto('/dashboard/status', { waitUntil: 'commit' })
+    await page.goto('/uptime', { waitUntil: 'commit' })
     await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByText(/degraded|partial system/i).first()).toBeVisible()
+    await expect(page.getByText('Redis')).toBeVisible()
+    await expect(page.getByText(/high latency/i)).toBeVisible()
   })
 
   test('uptime stats visible', async ({ page }) => {
-    await mockApiEndpoint(page, '**/api/monitor', {
-      overall: 'operational',
-      components: [],
-      uptime: { day: 100, week: 99.99, month: 99.97 },
-      checkedAt: new Date().toISOString(),
-    })
-    await page.goto('/dashboard/status', { waitUntil: 'commit' })
+    await mockApiEndpoint(page, '**/api/uptime**', upReport)
+    await page.goto('/uptime', { waitUntil: 'commit' })
     await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByText(/uptime|100\.00/i).first()).toBeVisible()
+    await expect(page.getByText('100.00%').first()).toBeVisible()
   })
 
-  test('offline state: shows retry on abort', async ({ page }) => {
-    await page.route('**/api/monitor', (route) => route.abort('failed'))
-    await page.goto('/dashboard/status', { waitUntil: 'commit' })
+  test('offline state: shows error banner on abort, Refresh stays available', async ({ page }) => {
+    await page.route('**/api/uptime**', (route) => route.abort('failed'))
+    await page.goto('/uptime', { waitUntil: 'commit' })
     await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByRole('button', { name: /retry/i })).toBeVisible()
+    // load() surfaces err.message in the error banner. The message text varies
+    // by engine ("Failed to fetch" / "NetworkError when attempting to fetch
+    // resource." / "Load failed"), so match the common fragments.
+    await expect(page.getByText(/failed|network/i).first()).toBeVisible()
+    await expect(page.getByRole('button', { name: /refresh/i })).toBeVisible()
   })
 
-  test('error state: shows error on 500', async ({ page }) => {
-    await page.route('**/api/monitor', (route) =>
+  test('error state: shows error banner on 500', async ({ page }) => {
+    await page.route('**/api/uptime**', (route) =>
       route.fulfill({
         status: 500,
         contentType: 'application/json',
         body: JSON.stringify({ error: 'Monitor unavailable' }),
       })
     )
-    await page.goto('/dashboard/status', { waitUntil: 'commit' })
+    await page.goto('/uptime', { waitUntil: 'commit' })
     await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByText(/failed|error|retry/i).first()).toBeVisible()
+    // load() throws `Server ${res.status}` for non-OK responses.
+    await expect(page.getByText(/server 500/i)).toBeVisible()
   })
 
   test('redirect to login when unauthenticated', async ({ page }) => {
@@ -879,7 +916,7 @@ test.describe('/dashboard/status', () => {
     // assertion below validates the outcome regardless of how the
     // navigation surface terminated.
     try {
-      await page.goto('/dashboard/status', { waitUntil: 'commit' })
+      await page.goto('/uptime', { waitUntil: 'commit' })
       await page.waitForLoadState('domcontentloaded')
     } catch (e) {
       if (!/interrupted by another navigation/i.test(String(e))) throw e

--- a/tests/e2e/15-ops-stack-services.spec.ts
+++ b/tests/e2e/15-ops-stack-services.spec.ts
@@ -15,8 +15,14 @@
  *   /services/python   /services/logs
  *   /stack/auth        /stack/hasura      /stack/postgresql   /stack/redis
  *   /stack/minio       /stack/mailhog     /stack/nginx
- *   /operations/scale  /operations/cleanup /operations/data   /operations/monitor
- *   /operations/snapshots /operations/deploy /operations/rollback
+ *
+ * Note: /operations/scale, /operations/cleanup, /operations/data,
+ * /operations/monitor, /operations/snapshots, /operations/deploy, and
+ * /operations/rollback were quarantined as dead pages (commit 6bf776a) and no
+ * longer exist under src/app/operations/ — their coverage was removed here.
+ * The modern replacement is /scale (src/app/scale/page.tsx), which has a
+ * different API contract (/api/scale, not /api/nself) and is not a drop-in
+ * equivalent; add fresh 7-state coverage for it as a separate ticket if desired.
  *
  * All tests mock /api/nself (POST) to avoid requiring a live CLI.
  * Tests that need two sequential API responses use request-count logic.
@@ -31,11 +37,6 @@ import { setupAuth } from './helpers'
 const SERVICE_LIST_JSON = JSON.stringify([
   { name: 'my-service', status: 'running', uptime: '2d', port: '3000' },
   { name: 'other-service', status: 'stopped', uptime: '', port: '' },
-])
-
-const SCALE_LIST_JSON = JSON.stringify([
-  { name: 'api', status: 'running', replicas: 2 },
-  { name: 'worker', status: 'stopped', replicas: 1 },
 ])
 
 const LOG_SERVICE_LIST = JSON.stringify([
@@ -649,112 +650,6 @@ test.describe('/services/logs — 7 UI states', () => {
     await page.waitForTimeout(600)
 
     expect(logCallCount).toBeGreaterThan(before)
-  })
-})
-
-// ── Operations / Scale ─────────────────────────────────────────────────────────
-
-test.describe('/operations/scale — 7 UI states', () => {
-  test.beforeEach(async ({ page }) => {
-    await setupAuth(page)
-  })
-
-  test('01 error — error card renders', async ({ page }) => {
-    await mockNselfError(page)
-    await page.goto('/operations/scale', { waitUntil: 'domcontentloaded' })
-    await expect(page.locator('text=Failed to load services')).toBeVisible()
-  })
-
-  test('02 empty — no services found', async ({ page }) => {
-    await mockNselfEmpty(page)
-    await page.goto('/operations/scale', { waitUntil: 'domcontentloaded' })
-    await expect(page.locator('text=No services found')).toBeVisible()
-  })
-
-  test('03 success — service cards with replica inputs', async ({ page }) => {
-    await mockNselfSuccess(page, SCALE_LIST_JSON)
-    await page.goto('/operations/scale', { waitUntil: 'domcontentloaded' })
-
-    // Use exact match scoped to main content to avoid strict-mode violation
-    // (sidebar nav may contain "API Keys" and "API Explorer" which also match 'text=api')
-    await expect(page.locator('main').getByText('api', { exact: true }).first()).toBeVisible()
-    await expect(page.locator('input[type="number"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("Apply")').first()).toBeVisible()
-  })
-
-  test('04 action-in-progress — Apply spinner shown', async ({ page }) => {
-    let resolve: (() => void) | undefined
-    const gate = new Promise<void>((r) => {
-      resolve = r
-    })
-    let callCount = 0
-    await page.route('**/api/nself', async (route) => {
-      callCount++
-      if (callCount === 1) {
-        return route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true, data: { stdout: SCALE_LIST_JSON, stderr: '' } }),
-        })
-      }
-      await gate
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ success: true, data: { stdout: '', stderr: '' } }),
-      })
-    })
-
-    await page.goto('/operations/scale', { waitUntil: 'domcontentloaded' })
-    await expect(page.locator('main').getByText('api', { exact: true }).first()).toBeVisible()
-    await page.locator('button:has-text("Apply")').first().click()
-    await expect(page.locator('.animate-spin').first()).toBeVisible()
-    resolve?.()
-  })
-
-  test('05 action-success — scale success badge shown', async ({ page }) => {
-    await mockNselfSequential(
-      page,
-      { success: true, data: { stdout: SCALE_LIST_JSON, stderr: '' } },
-      { success: true, data: { stdout: '', stderr: '' } }
-    )
-
-    await page.goto('/operations/scale', { waitUntil: 'domcontentloaded' })
-    await expect(page.locator('main').getByText('api', { exact: true }).first()).toBeVisible()
-    await page.locator('button:has-text("Apply")').first().click()
-    await page.waitForTimeout(500)
-
-    await expect(page.locator('text=scaled to')).toBeVisible()
-  })
-
-  test('06 action-error — scale error badge shown', async ({ page }) => {
-    await mockNselfSequential(
-      page,
-      { success: true, data: { stdout: SCALE_LIST_JSON, stderr: '' } },
-      { success: false, error: 'scale failed: quota exceeded' }
-    )
-
-    await page.goto('/operations/scale', { waitUntil: 'domcontentloaded' })
-    await expect(page.locator('main').getByText('api', { exact: true }).first()).toBeVisible()
-    await page.locator('button:has-text("Apply")').first().click()
-
-    await expect(page.locator('text=scale failed')).toBeVisible({ timeout: 15000 })
-  })
-
-  test('07 invalid-replica — error badge for non-numeric input', async ({ page }) => {
-    await mockNselfSuccess(page, SCALE_LIST_JSON)
-    await page.goto('/operations/scale', { waitUntil: 'domcontentloaded' })
-    await expect(page.locator('main').getByText('api', { exact: true }).first()).toBeVisible()
-
-    // Clear the input and enter an invalid value
-    const input = page.locator('input[type="number"]').first()
-    await input.fill('')
-    await input.type('abc')
-
-    await page.locator('button:has-text("Apply")').first().click()
-    await page.waitForTimeout(300)
-
-    await expect(page.locator('text=Invalid replica count')).toBeVisible()
   })
 })
 


### PR DESCRIPTION
## Root cause

E2E suites `14-dev-dashboard-pages.spec.ts` and `15-ops-stack-services.spec.ts` still tested `/dev/seed`, `/dashboard/status`, and `/operations/scale` — all deleted in the dead-page quarantine (6bf776a). Every E2E run since then failed those blocks deterministically on every browser and shard (element-not-found after the 20 s expect timeout, all retries exhausted). Test bugs, not code regressions; not flakiness or runner contention.

## Fixes

- `/dev/seed` block → `/database/seed` with the real `/api/database/seed` contract (`{ success, data: Seed[] }`) and actual UI text; offline test asserts the page's real fallback-to-empty behavior (no retry button exists).
- `/dashboard/status` block → `/uptime` with the real `/api/uptime` contract and real error-banner behavior.
- `/operations/scale` block removed — page deleted; successor `/scale` has a different API/UI and needs fresh coverage (noted in file header).

## Proof

- chromium: 121/121, run twice
- chromium + firefox + Mobile Chrome: 363/363

No `.skip`, no added retries, no weakened assertions.