### PR TITLE
ci: fix dependabot/fetch-metadata bad SHA pin (v3.1.0)

### DIFF
--- a/.github/workflows/dependabot-review.yml
+++ b/.github/workflows/dependabot-review.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@d7e4feee17f2c3e63c16f3bec7e1b5c9a5e8e4a8
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The pinned SHA d7e4feee... does not exist upstream — Dependabot Review Gate failed on every dependabot PR org-wide. Re-pinned to the real v3.1.0 SHA.