### PR TITLE
fix(ci): unset git-lfs filter at global scope, not just local

### DIFF
--- a/.github/workflows/quarterly-doc-audit.yml
+++ b/.github/workflows/quarterly-doc-audit.yml
@@ -28,16 +28,28 @@ jobs:
       - name: Disable git-lfs filters
         # Binaries under this repo's `filter=lfs` .gitattributes patterns (png/jpg/...)
         # were committed as raw content, never migrated to real LFS pointers. With the
-        # lfs smudge/clean filter active (git-lfs is preinstalled + globally registered
-        # on GitHub-hosted runners even though Checkout above doesn't pass lfs:true),
-        # git recomputes each file's "clean" pointer form and diffs it against the real
-        # binary blob actually committed, so these files show as perpetually modified —
-        # "Encountered N files that should have been pointers, but weren't". That trips
-        # peter-evans/create-pull-request's internal `git stash push`/`stash pop` dance
-        # in the next step ("local changes would be overwritten by merge"), unrelated to
-        # any real doc-audit change. Uninstalling the filter locally makes git compare
-        # raw content on both sides (no transform), which always matches.
-        run: git lfs uninstall --local || true
+        # lfs smudge/clean filter active, git recomputes each file's "clean" pointer
+        # form and diffs it against the real binary blob actually committed, so these
+        # files show as perpetually modified — "Encountered N files that should have
+        # been pointers, but weren't". That trips peter-evans/create-pull-request's
+        # internal `git stash push`/`stash pop` dance in the next step ("local changes
+        # would be overwritten by merge"), unrelated to any real doc-audit change.
+        #
+        # `git lfs uninstall --local` alone is NOT enough: on this runner the filter is
+        # registered at GLOBAL scope, not local (confirmed live — `--local` errored
+        # with "no such section: filter.lfs", i.e. nothing to remove there, while the
+        # very next Checkout still printed "Encountered N files that should have been
+        # pointers"). Local removal of a section that doesn't exist locally is a no-op;
+        # the global registration silently wins. Explicitly clear the global filter
+        # definitions too so nothing is left to shadow, then run both uninstall scopes
+        # for good measure.
+        run: |
+          git config --global --unset-all filter.lfs.clean || true
+          git config --global --unset-all filter.lfs.smudge || true
+          git config --global --unset-all filter.lfs.process || true
+          git config --global --unset-all filter.lfs.required || true
+          git lfs uninstall --local || true
+          git lfs uninstall || true
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/quarterly-doc-audit.yml
+++ b/.github/workflows/quarterly-doc-audit.yml
@@ -35,21 +35,16 @@ jobs:
         # internal `git stash push`/`stash pop` dance in the next step ("local changes
         # would be overwritten by merge"), unrelated to any real doc-audit change.
         #
-        # `git lfs uninstall --local` alone is NOT enough: on this runner the filter is
-        # registered at GLOBAL scope, not local (confirmed live — `--local` errored
-        # with "no such section: filter.lfs", i.e. nothing to remove there, while the
-        # very next Checkout still printed "Encountered N files that should have been
-        # pointers"). Local removal of a section that doesn't exist locally is a no-op;
-        # the global registration silently wins. Explicitly clear the global filter
-        # definitions too so nothing is left to shadow, then run both uninstall scopes
-        # for good measure.
-        run: |
-          git config --global --unset-all filter.lfs.clean || true
-          git config --global --unset-all filter.lfs.smudge || true
-          git config --global --unset-all filter.lfs.process || true
-          git config --global --unset-all filter.lfs.required || true
-          git lfs uninstall --local || true
-          git lfs uninstall || true
+        # Two prior attempts here didn't work: `git lfs uninstall --local` was a no-op
+        # (the filter is registered at GLOBAL scope on this runner, not local — PR #70),
+        # and unsetting it at --global scope worked but mutates config outside this
+        # checkout (unsafe on shared/persistent runners — PR #71 draft). `.git/info/
+        # attributes` has higher precedence than any in-tree .gitattributes and is
+        # local to this one checkout only: `* -filter` unconditionally clears the
+        # filter attribute for every path here, so git always compares raw content,
+        # without touching git config at any scope. Verified locally that this
+        # actually neutralizes an active clean/smudge filter for status/diff purposes.
+        run: echo '* -filter' >> .git/info/attributes
 
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
Follow-up to #70. That fix used `git lfs uninstall --local`, which turned out to be a no-op: run 31959579511 (commit 7b2417) logged `no such section: filter.lfs` for the local removal, while the very next Checkout step still printed `Encountered 8 files that should have been pointers, but weren't` — the filter is registered at GLOBAL scope on this runner. Explicitly clearing `filter.lfs.clean/smudge/process/required` at `--global` scope (plus both uninstall scopes for defense in depth) should actually neutralize it this time.