### PR TITLE
fix(ci): install nself audit tool to a user-writable path, not /usr/local/bin

### DIFF
--- a/.github/workflows/quarterly-doc-audit.yml
+++ b/.github/workflows/quarterly-doc-audit.yml
@@ -75,12 +75,18 @@ jobs:
             ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
             if curl -fsSL "https://github.com/nself-org/cli/releases/download/v${LATEST}/nself-${LATEST}-${OS}-${ARCH}.tar.gz" \
               | tar -xz -C /tmp --strip-components=1; then
-              # release tarballs nest a nself-<ver>-<os>-<arch>/ dir — strip it
-              sudo mv /tmp/nself /usr/local/bin/nself
+              # release tarballs nest a nself-<ver>-<os>-<arch>/ dir — strip it.
+              # Install to a user-writable path instead of /usr/local/bin: avoids
+              # depending on passwordless sudo, which self-hosted runners correctly
+              # don't grant by default (see nself-org/web#93).
+              mkdir -p "$HOME/.local/bin"
+              mv /tmp/nself "$HOME/.local/bin/nself"
+              echo "$HOME/.local/bin" >> "$GITHUB_PATH"
             else
               echo "::warning::nself release download/extract failed — audit tool unavailable, skipping"
             fi
           fi
+          export PATH="$HOME/.local/bin:$PATH"
           nself --version || true
 
       - name: Run doc audit


### PR DESCRIPTION
Consistency fix matching web (nself-org/web#93), where `sudo mv /tmp/nself /usr/local/bin/nself` failed on a self-hosted runner with no passwordless sudo. Not currently broken here (GitHub-hosted runner has baked-in passwordless sudo), but installs to `$HOME/.local/bin` for consistency and to avoid needless privilege escalation.