### PR TITLE
fix(ci): make doc-audit autofix strictly opt-in

### DIFF
--- a/.github/workflows/quarterly-doc-audit.yml
+++ b/.github/workflows/quarterly-doc-audit.yml
@@ -9,7 +9,15 @@ on:
       apply_autofix:
         description: 'Apply safe auto-fixes and open a PR'
         required: false
-        default: 'true'
+        # Opt-in, NOT the default. The autofix rewrites prose via the released
+        # `nself audit docs --fix`, which deleted banned adjectives at word level and
+        # produced broken English/Markdown in public wikis (nself-org/plugins#34 and
+        # #36, both closed unmerged, 48 files each). Root cause fixed in
+        # nself-org/cli#216, but this workflow downloads the latest RELEASE, so the old
+        # behaviour ships until a CLI release includes that fix. Scheduled runs pass no
+        # inputs, so the condition below is `== 'true'` (strict opt-in) rather than
+        # `!= 'false'`, which would have let the quarterly cron rewrite docs unattended.
+        default: 'false'
 
 permissions:
   contents: write
@@ -105,7 +113,7 @@ jobs:
 
       - name: Apply auto-fixes (banned words only)
         id: fix
-        if: ${{ github.event.inputs.apply_autofix != 'false' }}
+        if: ${{ github.event.inputs.apply_autofix == 'true' }}
         run: |
           set +e
           nself audit docs \
@@ -125,7 +133,7 @@ jobs:
       # Discard everything outside the doc paths we actually intend to commit,
       # so the tree is clean apart from the auto-fixes.
       - name: Discard non-doc changes before opening PR
-        if: ${{ github.event.inputs.apply_autofix != 'false' }}
+        if: ${{ github.event.inputs.apply_autofix == 'true' }}
         run: |
           set -euo pipefail
           echo "Working tree before cleanup:"
@@ -138,7 +146,7 @@ jobs:
           git status --porcelain | head -20
 
       - name: Open auto-fix PR
-        if: ${{ github.event.inputs.apply_autofix != 'false' }}
+        if: ${{ github.event.inputs.apply_autofix == 'true' }}
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: 'docs(audit): quarterly sweep ${{ steps.quarter.outputs.label }}'


### PR DESCRIPTION
Makes the quarterly doc audit report-only by default.

## Why

`nself audit docs --fix` deletes banned adjectives at **word level**, which is fine for conjunctive filler but breaks any adjective modifying a noun — including the Markdown around it:

| Before | After |
|---|---|
| `- [ ] Wiki documentation is comprehensive` | `- [ ] Wiki documentation is ` |
| `Comprehensive guide for database migrations` | ` guide for database migrations` |
| `**Comprehensive backup strategies**` | `** backup strategies**` (no longer bold) |
| `The most powerful way to query your data:` | `The most way to query your data:` |

The audit auto-opened nself-org/plugins#34 rewriting **48 public wiki files** this way. I closed it; a later run regenerated the identical PR as #36, which I also closed. It will keep regenerating.

## Two changes

1. `apply_autofix` input default `"true"` -> `"false"`.
2. Step conditions `apply_autofix != 'false'` -> `== 'true'`.

**(2) matters more than (1).** Scheduled runs pass no inputs at all, so `github.event.inputs.apply_autofix` is empty and `!= 'false'` evaluated **true** — the quarterly cron would rewrite public docs unattended. `== 'true'` makes it strict opt-in on both the cron and dispatch paths.

The audit still runs and still reports every finding; it just no longer rewrites prose.

## Re-enabling

Root cause is fixed in nself-org/cli#216 (`safeReplacement` returns `(replacement, safe)`; adjectives are advisory-only). This workflow downloads the latest **released** `nself`, so the old behaviour ships until a CLI release includes that fix. After such a release, dispatch with `apply_autofix=true` to confirm, then flip the default back if desired.

Verified: YAML parses; `default` resolves to `false`; no `!= 'false'` conditions remain.