### PR TITLE
fix(admin): move type-check out of Vercel build to stop 46min tsc-phase timeout

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -17,6 +17,14 @@ const nextConfig = {
   experimental: {
     optimizeCss: true,
   },
+  // Type-checking is enforced by the "TypeScript Coverage Gate (admin)" GitHub
+  // Action pre-merge, not by the Vercel production build. Running `tsc` again
+  // inside `next build` on a cold-cache prod build was hanging past Vercel's
+  // 46-minute ceiling (BUILD_EXCEEDED_MAXIMUM_TIME). Types are still fully
+  // enforced in CI — this only removes the redundant in-build check.
+  typescript: {
+    ignoreBuildErrors: true,
+  },
   // Image optimization
   images: {
     formats: ['image/avif', 'image/webp'],


### PR DESCRIPTION
## Root cause

Vercel's production build of the `admin` Next.js app was hanging inside `next build`'s in-build TypeScript type-check phase (\"Running TypeScript ...\") on cold-cache builds, running all the way to Vercel's 46-minute ceiling (`BUILD_EXCEEDED_MAXIMUM_TIME`). Confirmed via Vercel build logs.

## Change

`next.config.mjs`: added
```js
typescript: {
  ignoreBuildErrors: true,
},
```
merged into the existing config (no other options touched), with a comment explaining why.

Type safety is unaffected — the "TypeScript Coverage Gate (admin)" GitHub Action already gates types pre-merge, and the repo's `ci.yml` also runs a dedicated `type-check` job. This change only removes the redundant, hang-prone in-build type-check from the Vercel production build; nothing about type enforcement changes.

ESLint-during-build was left untouched — the diagnosis only implicated the TypeScript phase, not ESLint, so `eslint.ignoreDuringBuilds` was not added even though a separate lint CI gate (`ci.yml` "Lint & Format" job) does exist.

## Local verification

Ran `pnpm install --frozen-lockfile` then `NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 pnpm run build` locally:
- Exit code 0.
- Total time: 1m48s.
- Build log shows `Skipping validation of types` / `Finished TypeScript config validation in 40ms`, confirming the tsc phase is now skipped instead of running to completion (or hanging).
- `.next/` output produced normally (server/static/types/cache present, full route manifest printed).

Did not do a side-by-side timed comparison against the pre-fix build (would require reverting and re-running a full cold-cache build, which is the slow/hang-prone path this PR removes) — the log evidence above is the verification.

## Not merging

Build-policy change — leaving for human review per the task instructions.