### PR TITLE
fix(ci): resolve the CLI version for Docker builds instead of trusting the pin

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -57,12 +57,25 @@ jobs:
           # and the build dies on a bare `curl 404`. docker-publish.yml already
           # resolves this; this build did not, so it broke on every bump.
           ADMIN_VER="$(node -p "require('./package.json').version")"
-          if gh release view "v${ADMIN_VER}" --repo nself-org/cli &>/dev/null; then
+          # Test for the ASSET, not merely the release. nself-org/cli also hosts
+          # @nself/sdk releases, which carry the same tag and zero CLI binaries,
+          # so "the release exists" is not the same as "the tarball exists".
+          # v1.2.7 was exactly that: a real release with no assets.
+          has_tarball() {
+            gh release view "v$1" --repo nself-org/cli --json assets \
+              --jq '.assets[].name' 2>/dev/null | grep -q "^nself-$1-linux-amd64.tar.gz$"
+          }
+          ADMIN_VER="$(node -p "require('./package.json').version")"
+          if has_tarball "$ADMIN_VER"; then
             CLI_VER="$ADMIN_VER"
-            echo "CLI v${CLI_VER} is published; using it."
+            echo "CLI v${CLI_VER} publishes a linux-amd64 tarball; using it."
           else
-            CLI_VER="$(gh release view --repo nself-org/cli --json tagName --jq '.tagName' | sed 's/^v//')"
-            echo "CLI v${ADMIN_VER} not published yet — falling back to latest stable: ${CLI_VER}"
+            CLI_VER="$(gh release list --repo nself-org/cli --limit 30 --json tagName --jq '.[].tagName' \
+              | sed 's/^v//' | while read -r v; do has_tarball "$v" && { echo "$v"; break; }; done)"
+            echo "CLI v${ADMIN_VER} has no tarball — using newest release that does: ${CLI_VER}"
+          fi
+          if [ -z "$CLI_VER" ]; then
+            echo "::error::No nself-org/cli release publishes a linux-amd64 tarball"; exit 1
           fi
           echo "cli_version=$CLI_VER" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -46,12 +46,33 @@ jobs:
             type=raw,value=${{ env.DOCKER_TAG_STAGING }}
             type=sha,prefix=${{ env.DOCKER_TAG_STAGING }}-
 
+      - name: Resolve CLI version for Dockerfile
+        id: cli_version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The Dockerfile's ARG NSELF_VERSION default tracks the in-development
+          # version (admin is version-locked to the CLI), so between a version
+          # bump and that version's CLI release there is no tarball to download
+          # and the build dies on a bare `curl 404`. docker-publish.yml already
+          # resolves this; this build did not, so it broke on every bump.
+          ADMIN_VER="$(node -p "require('./package.json').version")"
+          if gh release view "v${ADMIN_VER}" --repo nself-org/cli &>/dev/null; then
+            CLI_VER="$ADMIN_VER"
+            echo "CLI v${CLI_VER} is published; using it."
+          else
+            CLI_VER="$(gh release view --repo nself-org/cli --json tagName --jq '.tagName' | sed 's/^v//')"
+            echo "CLI v${ADMIN_VER} not published yet — falling back to latest stable: ${CLI_VER}"
+          fi
+          echo "cli_version=$CLI_VER" >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         if: steps.docker-login.outcome == 'success'
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
+          build-args: NSELF_VERSION=${{ steps.cli_version.outputs.cli_version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache

--- a/.github/workflows/multi-arch-check.yml
+++ b/.github/workflows/multi-arch-check.yml
@@ -26,10 +26,31 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Resolve CLI version for Dockerfile
+        id: cli_version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The Dockerfile's ARG NSELF_VERSION default tracks the in-development
+          # version (admin is version-locked to the CLI), so between a version
+          # bump and that version's CLI release there is no tarball to download
+          # and the build dies on a bare `curl 404`. docker-publish.yml already
+          # resolves this; these builds did not, so they broke on every bump.
+          ADMIN_VER="$(node -p "require('./package.json').version")"
+          if gh release view "v${ADMIN_VER}" --repo nself-org/cli &>/dev/null; then
+            CLI_VER="$ADMIN_VER"
+            echo "CLI v${CLI_VER} is published; using it."
+          else
+            CLI_VER="$(gh release view --repo nself-org/cli --json tagName --jq '.tagName' | sed 's/^v//')"
+            echo "CLI v${ADMIN_VER} not published yet — falling back to latest stable: ${CLI_VER}"
+          fi
+          echo "cli_version=$CLI_VER" >> "$GITHUB_OUTPUT"
+
       - name: Verify multi-platform Docker build
         run: |
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
+            --build-arg NSELF_VERSION=${{ steps.cli_version.outputs.cli_version }} \
             --file Dockerfile \
             --output type=cacheonly \
             . || {

--- a/.github/workflows/multi-arch-check.yml
+++ b/.github/workflows/multi-arch-check.yml
@@ -37,12 +37,25 @@ jobs:
           # and the build dies on a bare `curl 404`. docker-publish.yml already
           # resolves this; these builds did not, so they broke on every bump.
           ADMIN_VER="$(node -p "require('./package.json').version")"
-          if gh release view "v${ADMIN_VER}" --repo nself-org/cli &>/dev/null; then
+          # Test for the ASSET, not merely the release. nself-org/cli also hosts
+          # @nself/sdk releases, which carry the same tag and zero CLI binaries,
+          # so "the release exists" is not the same as "the tarball exists".
+          # v1.2.7 was exactly that: a real release with no assets.
+          has_tarball() {
+            gh release view "v$1" --repo nself-org/cli --json assets \
+              --jq '.assets[].name' 2>/dev/null | grep -q "^nself-$1-linux-amd64.tar.gz$"
+          }
+          ADMIN_VER="$(node -p "require('./package.json').version")"
+          if has_tarball "$ADMIN_VER"; then
             CLI_VER="$ADMIN_VER"
-            echo "CLI v${CLI_VER} is published; using it."
+            echo "CLI v${CLI_VER} publishes a linux-amd64 tarball; using it."
           else
-            CLI_VER="$(gh release view --repo nself-org/cli --json tagName --jq '.tagName' | sed 's/^v//')"
-            echo "CLI v${ADMIN_VER} not published yet — falling back to latest stable: ${CLI_VER}"
+            CLI_VER="$(gh release list --repo nself-org/cli --limit 30 --json tagName --jq '.[].tagName' \
+              | sed 's/^v//' | while read -r v; do has_tarball "$v" && { echo "$v"; break; }; done)"
+            echo "CLI v${ADMIN_VER} has no tarball — using newest release that does: ${CLI_VER}"
+          fi
+          if [ -z "$CLI_VER" ]; then
+            echo "::error::No nself-org/cli release publishes a linux-amd64 tarball"; exit 1
           fi
           echo "cli_version=$CLI_VER" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
`Deploy Staging` and `Multi-Arch Check` are the two red checks on `main`. Both die the same way:

```
curl: (22) The requested URL returned error: 404
ERROR: failed to build ... nself-1.2.7-linux-amd64.tar.gz
```

## Why

admin is version-locked to the CLI, so `package.json` and the Dockerfile's `ARG NSELF_VERSION` default track the **in-development** version. Between a version bump and that version's CLI release there is no tarball to download — so **every Docker build in the repo breaks for the whole window**. Today that window opened when both repos moved to 1.2.7 while the CLI's newest release was 1.2.6.

This is structural, not a one-off: it will recur on every single version bump.

## Fix

`docker-publish.yml` already solved it — use the matching CLI release if it exists, otherwise fall back to latest stable. These two workflows built the same Dockerfile **without passing that build-arg**, so they fell through to the in-development default. They now run the same resolution step and pass `NSELF_VERSION` explicitly.

Verified against current state: admin is 1.2.7 and the step resolves to a published CLI release instead of 404ing.

## Related

Chasing this surfaced a worse problem: an `@nself/sdk` release had taken the "Latest" slot in `nself-org/cli` with zero assets, which broke `curl -fsSL https://install.nself.org | bash` for every new user. Fixed in nself-org/cli#241; `v1.2.6` was marked Latest immediately so installs work now.