### PR TITLE
Audit CLI call sites against the 43 commands that moved to plugins

### DIFF
--- a/src/app/api/config/ssl/generate-local/route.ts
+++ b/src/app/api/config/ssl/generate-local/route.ts
@@ -1,4 +1,3 @@
-import { findNselfPath } from '@/lib/nself-path'
 import { getProjectPath } from '@/lib/paths'
 import { requireAuth } from '@/lib/require-auth'
 import { execFile, spawn } from 'child_process'
@@ -44,27 +43,17 @@ export async function POST(request: NextRequest): Promise<Response | NextRespons
       )
     }
 
-    // Try nself ssl bootstrap first
-    try {
-      const nselfPath = await findNselfPath()
-      await fs.access(nselfPath)
-
-      const { stdout, stderr } = await execFileAsync(nselfPath, ['ssl', 'bootstrap'], {
-        cwd: projectPath,
-        timeout: 60000,
-      })
-
-      return NextResponse.json({
-        success: true,
-        data: {
-          method: 'nself',
-          output: stdout,
-          warnings: stderr || undefined,
-        },
-      })
-    } catch {
-      // nself not available, use mkcert directly
-    }
+    // This used to try `nself ssl bootstrap` first and fall back to mkcert when
+    // that failed. The fallback never ran, because the attempt never failed:
+    // `bootstrap` has never been a subcommand of `nself ssl`, and cobra answers
+    // an unknown subcommand by printing help and exiting 0. So this endpoint
+    // reported { success: true, method: 'nself' } while generating no
+    // certificates at all, and the working path below was unreachable.
+    //
+    // There is no nself command to call here. `nself trust ssl` provisions via
+    // certbot with DNS-01, which needs a public domain; local development certs
+    // are mkcert's job, which is what the rest of this handler does. So the
+    // attempt is gone rather than repointed.
 
     // Read domain from .env
     let baseDomain = 'localhost'

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -112,6 +112,16 @@ interface CLICommandGroup {
   description: string
   commandCount: number
   commands: CLICommand[]
+  /**
+   * Set when this group's commands live in a plugin rather than the CLI core.
+   *
+   * nSelf 1.3.0 moved 43 commands out of the binary. They still work exactly as
+   * documented here, but only once the plugin is installed — so listing them
+   * without saying that sends someone to a command their machine does not have.
+   * The value is the plugin name to install, which is not always the command
+   * name: `nself sentry` lives in `sentry-cli`, `nself billing` in `tenant`.
+   */
+  plugin?: string
 }
 
 const CATEGORIES = [
@@ -216,7 +226,8 @@ const CLI_COMMAND_GROUPS: CLICommandGroup[] = [
       },
       {
         command: 'nself monitor',
-        description: 'Open the monitoring dashboard with real-time service metrics',
+        description:
+          'Open the monitoring dashboard with real-time service metrics (plugin: nself install monitor)',
         uiPath: '/monitor',
         uiLabel: 'Monitor',
       },
@@ -254,7 +265,8 @@ const CLI_COMMAND_GROUPS: CLICommandGroup[] = [
       },
       {
         command: 'nself audit',
-        description: 'Run a security and configuration audit on the project setup',
+        description:
+          'Run a security and configuration audit on the project setup (plugin: nself install audit)',
         uiPath: '/system/security',
         uiLabel: 'Security',
       },
@@ -337,6 +349,7 @@ const CLI_COMMAND_GROUPS: CLICommandGroup[] = [
     icon: Users,
     description: 'Tenant lifecycle, members, settings, billing, branding, and more',
     commandCount: 50,
+    plugin: 'tenant',
     commands: [
       {
         command: 'nself tenant init',
@@ -525,6 +538,7 @@ const CLI_COMMAND_GROUPS: CLICommandGroup[] = [
     icon: Server,
     description: 'Cloud providers, Kubernetes, and Helm chart management',
     commandCount: 38,
+    plugin: 'infra',
     commands: [
       {
         command: 'nself infra provider list',
@@ -2081,6 +2095,12 @@ function CLIReferenceSection() {
                     <p className="mt-0.5 text-sm text-zinc-500 dark:text-zinc-400">
                       {group.description}
                     </p>
+                    {group.plugin && (
+                      <p className="mt-1 text-xs text-amber-600 dark:text-amber-500">
+                        Ships as a plugin since 1.3.0 — install with{' '}
+                        <code className="font-mono">nself install {group.plugin}</code>
+                      </p>
+                    )}
                   </div>
                   {isExpanded ? (
                     <ChevronDown className="h-5 w-5 flex-shrink-0 text-zinc-400" />


### PR DESCRIPTION
The audit the 1.3.0 release listed as outstanding.

## One real execution site, already broken

`/api/config/ssl/generate-local` ran `nself ssl bootstrap` and fell back to mkcert if it failed. **The fallback never ran, because the attempt never failed:** `bootstrap` has never been a subcommand of `nself ssl` — not before the move, not after — and cobra answers an unknown subcommand by printing help and exiting 0.

So the endpoint returned `{ success: true, method: 'nself' }` while generating no certificates, and the working path was unreachable.

There is nothing to repoint it at: `nself trust ssl setup` is certbot DNS-01, which needs a public domain, and local certs are mkcert's job — which the rest of the handler already does. The dead attempt is removed so mkcert always runs.

## Everything else was display text

~60 strings name commands that are now plugins. Not broken, but listing `nself tenant create` without saying it needs a plugin sends someone to a command they do not have.

`CLICommandGroup` takes an optional `plugin` field; the group header renders the install line. Tagged tenant (25 commands) and infra (15); the lone `audit` and `monitor` entries carry it in their description.

The plugin name is not always the command name (`nself sentry` → `sentry-cli`, `nself billing` → `tenant`), so the field holds the name to install rather than deriving it.